### PR TITLE
scoped_timer: deadlock in thread pool based implementation since 4.8.10

### DIFF
--- a/src/util/scoped_timer.cpp
+++ b/src/util/scoped_timer.cpp
@@ -104,10 +104,10 @@ public:
         else {
             s->cv.notify_one();
         }
+        s->m_mutex.unlock();
     }
 
     ~imp() {
-        s->m_mutex.unlock();
         while (s->work == 1)
             std::this_thread::yield();
     }


### PR DESCRIPTION
Unlock immediately, not at destruct time, to avoid interactions between locks.